### PR TITLE
Add option to skip showing dropdown on empty results set

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ You can look at different show cases for it here as [Component](https://rawgit.c
   * **`display-property-name`**, string, key name of text to show. default is `value`
   * **`select-value-of`**, string, when selected, return the value of this key as a selected item
   * **`blank-option-text`**, string, guide text to allow empty value to be selected as in empty value of `option` tag.
+  * **`hide-on-no-match-found`**, if set to true, results dropdown will not be shown on empty autocomplete result
   * **`no-match-found-text`**, string | `NguiAutoCompleteNoMatchFoundMessage`, guide text to show no result found with optional CTA link.
   * **`valueChanged`** / **`ngModelChange`**, callback function that is executed when a new drop-down is selected.
      e.g. `(valueChanged)="myCallback($event)"`  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngui/auto-complete",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Angular Input Autocomplete",
   "license": "MIT",
   "main": "dist/auto-complete.umd.js",

--- a/src/auto-complete.component.ts
+++ b/src/auto-complete.component.ts
@@ -173,6 +173,7 @@ export class NguiAutoCompleteComponent implements OnInit {
     @Input('ignore-accents') public ignoreAccents: boolean = true;
     @Input('filters') public filters: AutoCompleteFilter[] = [];
 
+    @Input('hide-on-no-match-found') public hideOnNoMatchFound: boolean = false;
     @Input('no-match-found-text')
     public set noMatchFoundText(noMatchFoundMessage: string | NguiAutoCompleteNoMatchFoundMessage) {
         if (typeof noMatchFoundMessage === 'string') {
@@ -441,7 +442,7 @@ export class NguiAutoCompleteComponent implements OnInit {
     get emptyList(): boolean {
         return !(
             this.isLoading ||
-            (this.minCharsEntered && !this.isLoading && !this.filteredList.length) ||
+            (this.minCharsEntered && !this.isLoading && !this.filteredList.length && !this.hideOnNoMatchFound) ||
             (this.filteredList.length)
         );
     }

--- a/src/auto-complete.directive.ts
+++ b/src/auto-complete.directive.ts
@@ -49,6 +49,7 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
     @Input('extFormControl') public extFormControl: AbstractControl;
     @Input('z-index') public zIndex: string = '1';
     @Input('is-rtl') public isRtl: boolean = false;
+    @Input('hide-on-no-match-found') public hideOnNoMatchFound: boolean = false;
 
     @Input('no-match-found-text')
     public set noMatchFoundText(noMatchFoundMessage: string | NguiAutoCompleteNoMatchFoundMessage) {
@@ -207,6 +208,7 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
         component.loadingTemplate = this.loadingTemplate;
         component.listFormatter = this.listFormatter;
         component.blankOptionText = this.blankOptionText;
+        component.hideOnNoMatchFound = this.hideOnNoMatchFound;
         component.noMatchFoundMessage = this.noMatchFoundMessage;
         component.tabToSelect = this.tabToSelect;
         component.selectOnBlur = this.selectOnBlur;


### PR DESCRIPTION
Add configuration option to allow hiding autocomplte dropdown on empty result set (instead of showing built-in or custom 'No matches found' message)