### PR TITLE
feature/SP-2643-secondary-industry-experience-li

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngui/auto-complete",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Angular Input Autocomplete",
   "license": "MIT",
   "main": "dist/auto-complete.umd.js",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build:umd": "webpack --mode development",
     "build:app": "webpack --mode production --config app/webpack.config",
     "build-and-publish": "npm run build && npm version patch && npm publish --access=public",
-    "tslint": "tslint"
+    "tslint": "tslint",
+    "pushLocal": "npm run build:ngc && yalc push"
   },
   "dependencies": {
     "@ngui/utils": "^0.8.1"
@@ -36,6 +37,7 @@
     "@ngtools/webpack": "~6.0.8",
     "@types/hammerjs": "^2.0.35",
     "@types/node": "^10.5.2",
+    "@types/tapable": "1.0.0",
     "@types/uglify-js": "^3.0.2",
     "@types/webpack": "^4.4.5",
     "angular2-template-loader": "^0.6.2",

--- a/src/auto-complete.component.ts
+++ b/src/auto-complete.component.ts
@@ -142,6 +142,10 @@ import { NguiAutoCompleteNoMatchFoundMessage } from './model/no-match-found-mess
         .ngui-auto-complete-filter-item input {
             width: auto;
         }
+
+        .limit-top {
+            overflow: hidden auto;
+        }
     `
     ],
     encapsulation: ViewEncapsulation.None
@@ -201,6 +205,9 @@ export class NguiAutoCompleteComponent implements OnInit {
     public minCharsEntered: boolean = false;
     public itemIndex: number = null;
     public keyword: string;
+    public itemHeight: number = 0;
+    public triggerInputHeight: number = 0;
+    public maxHeightTopGap: number = 0;
 
     private el: HTMLElement;           // this component  element `<ngui-auto-complete>`
     private timer = 0;
@@ -290,6 +297,7 @@ export class NguiAutoCompleteComponent implements OnInit {
             if (this.maxNumList) {
                 this.filteredList = this.filteredList.slice(0, this.maxNumList);
             }
+            this.calculateHeightFits();
 
         } else {                 // remote source
             this.isLoading = true;
@@ -308,6 +316,7 @@ export class NguiAutoCompleteComponent implements OnInit {
                         if (this.maxNumList) {
                             this.filteredList = this.filteredList.slice(0, this.maxNumList);
                         }
+                        this.calculateHeightFits();
                     },
                     (error) => null,
                     () =>  this.zone.run(() => this.isLoading = false) // complete
@@ -320,6 +329,7 @@ export class NguiAutoCompleteComponent implements OnInit {
                         if (this.maxNumList) {
                             this.filteredList = this.filteredList.slice(0, this.maxNumList);
                         }
+                        this.calculateHeightFits();
                     },
                     (error) => null,
                     () => this.zone.run(() => this.isLoading = false) // complete
@@ -447,4 +457,26 @@ export class NguiAutoCompleteComponent implements OnInit {
         );
     }
 
+    private calculateHeightFits() {
+        // Filter items height = 50px;
+        const heighByFilter = this.filters.length > 0 ? 50 : 0;
+        const heighByResultItems = this.filteredList.length * this.itemHeight;
+
+        const elBottom = this.el.getBoundingClientRect().bottom;
+        const listHeight = heighByResultItems + heighByFilter;
+        const fitsInPage =  elBottom + listHeight < window.innerHeight;
+
+        if (!fitsInPage) {
+            this.el.style.top = 'auto';
+            this.el.style.bottom = `${this.triggerInputHeight}px`;
+            const topOverflowedSection = elBottom - listHeight + this.triggerInputHeight - this.maxHeightTopGap;
+            // check if it fits based on the top of window
+            if ( topOverflowedSection < 0) {
+                // reduce 20 for a small visual gap from top.
+                const maxListHeight = elBottom - this.maxHeightTopGap - this.triggerInputHeight - 20;
+                this.el.classList.add('limit-top');
+                this.el.style.height = `${maxListHeight}px`;
+            }
+        }
+    }
 }

--- a/src/auto-complete.directive.ts
+++ b/src/auto-complete.directive.ts
@@ -39,6 +39,8 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
     @Input('header-item-template') public headerItemTemplate = null;
     @Input('ignore-accents') public ignoreAccents: boolean = true;
     @Input('filters') public filters: AutoCompleteFilter[];
+    @Input('itemHeight') public itemHeight = 37;
+    @Input('max-height-top-gap') public maxHeightTopGap = 0;
 
     @Input() public ngModel: string;
     @Input('form') public form: FormGroup;
@@ -217,6 +219,9 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
         component.headerItemTemplate = this.headerItemTemplate;
         component.ignoreAccents = this.ignoreAccents;
         component.filters = this.filters || [];
+        component.itemHeight = this.itemHeight;
+        component.triggerInputHeight = this.inputEl.getBoundingClientRect().height;
+        component.maxHeightTopGap = this.maxHeightTopGap;
 
         component.valueSelected.subscribe(this.selectNewValue);
         component.textEntered.subscribe(this.enterNewText);
@@ -235,8 +240,8 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
         this.revertValue = typeof this.ngModel !== 'undefined' ? this.ngModel : this.inputEl.value;
 
         setTimeout(() => {
-            component.reloadList(this.inputEl.value);
             this.styleAutoCompleteDropdown();
+            component.reloadList(this.inputEl.value);
             component.dropdownVisible = true;
         });
     }


### PR DESCRIPTION
Calculates after the results are ready if there is enough space below the triggering input to display as normal, if not then shows the content above the triggering input. 
If there is no full space below and above the trigger element it will still put above but will set a top limit so the content wrapper is still visible but the result items can scroll. 