### PR TITLE
Relates to SP-3955 - Implement hiding of whole container instead of nested list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-complete",
-  "version": "0.0.0",
+  "version": "3.0.1",
   "description": "Angular Input Autocomplete",
   "license": "MIT",
   "scripts": {

--- a/projects/auto-complete/src/lib/auto-complete.component.ts
+++ b/projects/auto-complete/src/lib/auto-complete.component.ts
@@ -2,6 +2,7 @@ import {
   Component,
   ElementRef,
   EventEmitter,
+  HostBinding,
   Input,
   NgZone,
   OnInit,
@@ -29,7 +30,7 @@ import { NguiAutoCompleteNoMatchFoundMessage } from './model/no-match-found-mess
              [(ngModel)]="keyword"/>
 
       <!-- dropdown that user can select -->
-      <ul *ngIf="dropdownVisible" [class.empty]="emptyList">
+      <ul *ngIf="dropdownVisible">
         <li *ngIf="headerItemTemplate && filteredList.length" class="header-item"
             [innerHTML]="headerItemTemplate"></li>
         <li *ngFor="let filter of filters; let i=index; trackBy: trackByIndex"
@@ -104,10 +105,6 @@ import { NguiAutoCompleteNoMatchFoundMessage } from './model/no-match-found-mess
       border: 1px solid #ccc;
       box-sizing: border-box;
       animation: slideDown 0.1s;
-    }
-
-    .ngui-auto-complete > ul.empty {
-      display: none;
     }
 
     .ngui-auto-complete > ul li {
@@ -186,6 +183,8 @@ export class NguiAutoCompleteComponent implements OnInit {
   @Output() public textEntered = new EventEmitter();
   @Output() public filterSelected = new EventEmitter();
   @Output() public noMatchFoundAction = new EventEmitter();
+
+  @HostBinding('style.display') get display() { return !this.emptyList ? 'inline-block' : 'none' ; }
 
   @ViewChild('autoCompleteInput') public autoCompleteInput: ElementRef;
   @ViewChild('autoCompleteContainer') public autoCompleteContainer: ElementRef;

--- a/projects/auto-complete/src/lib/auto-complete.directive.ts
+++ b/projects/auto-complete/src/lib/auto-complete.directive.ts
@@ -306,7 +306,6 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
       this.acDropdownEl.style.position = 'absolute';
       this.acDropdownEl.style.zIndex = this.zIndex;
       this.acDropdownEl.style[directionOfStyle] = '0';
-      this.acDropdownEl.style.display = 'inline-block';
 
       if (!this.outerInputElement) {
         if (closeToBottom) {


### PR DESCRIPTION
Implement hiding of whole container instead of nested list when no matches are available. This is to avoid rendering of zero-height dropdown.